### PR TITLE
feat: add per-pair scheduling and quiet hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Mantiene cartelle allineate, gestisce conflitti, salva versioni precedenti e off
   - velocità media ed ETA
   - pulsanti Avvia, Pausa, Stop
 - ⏱️ **Monitoraggio continuo** (ripete la sync ogni N secondi)
+- 🗓️ **Pianificazione per coppia** con intervalli dedicati e finestre silenziose
 - ⚡ **Portabilità totale**:
   - Nessuna dipendenza esterna (solo Python + Tkinter)
   - Pacchettizzabile in un singolo eseguibile con **PyInstaller**
@@ -142,7 +143,6 @@ Aggiungi screenshot, icone, traduzioni o nuove funzionalità.
 
 ## 📌 TODO / Idee future
 
-* 📅 Pianificazione avanzata per singola coppia
 * 🌐 Integrazione con cloud (Dropbox/Google Drive/OneDrive)
 
 ---


### PR DESCRIPTION
## Summary
- allow each sync pair to define its own interval and silent time window
- extend GUI editor and list to configure and display scheduling options
- ensure monitor loop respects per-pair schedules and quiet hours

## Testing
- `python -m py_compile bisync_plus.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c2064a448326b35b1e132cd65b71